### PR TITLE
Fix search in stop selector in trip finder to match behaviour

### DIFF
--- a/Haltestellenmonitor1-DD/TripFinder/Views/ConnectionStopSelectionView.swift
+++ b/Haltestellenmonitor1-DD/TripFinder/Views/ConnectionStopSelectionView.swift
@@ -153,7 +153,7 @@ struct ConnectionStopSelectionView: View {
         if searchText.isEmpty {
             return stops
         } else {
-            return stops.filter { $0.name.lowercased().contains(searchText.lowercased()) }
+            return stops.filter { $0.getFullName().lowercased().contains(searchText.lowercased()) }
         }
     }
 


### PR DESCRIPTION
The stop selector in the Trip Finder didn't have the ability to search for city names (this is essential for all the creatively named "Bahnhof <City>" stops. Even though it could do that in the stops view.

Should be a quick fix, I hope this can be included in the next release.